### PR TITLE
Add ability to run parallel instances of the server. Fix small issues

### DIFF
--- a/player/src/main/java/com/focusit/jsflight/player/cli/config/CliConfig.java
+++ b/player/src/main/java/com/focusit/jsflight/player/cli/config/CliConfig.java
@@ -111,6 +111,9 @@ public class CliConfig implements IConfig
     private Integer xvfbDisplayUpperBound = DefaultValues.XVFB_ZERO_DISPLAY;
 
 
+    @Parameter(names = { "--targetBaseUrl" }, description = "Base url of the target server. Will be used for filling templates in event url", required = true)
+    private String targetBaseUrl;
+
 
     public Boolean shouldShowUsage()
     {
@@ -205,6 +208,11 @@ public class CliConfig implements IConfig
     public String getPathToPreProcessorScript()
     {
         return pathToPreProcessorScript;
+    }
+
+    @Override
+    public String getTargetBaseUrl() {
+        return targetBaseUrl;
     }
 
     @Override

--- a/player/src/main/java/com/focusit/jsflight/player/cli/config/IConfig.java
+++ b/player/src/main/java/com/focusit/jsflight/player/cli/config/IConfig.java
@@ -73,4 +73,6 @@ public interface IConfig
     Boolean shouldMakeScreenshots();
 
     String getPathToPreProcessorScript();
+
+    String getTargetBaseUrl();
 }

--- a/player/src/main/java/com/focusit/jsflight/player/cli/config/PropertiesConfig.java
+++ b/player/src/main/java/com/focusit/jsflight/player/cli/config/PropertiesConfig.java
@@ -2,6 +2,7 @@ package com.focusit.jsflight.player.cli.config;
 
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.validators.PositiveInteger;
 import com.focusit.jsflight.player.constants.BrowserType;
 import org.slf4j.Logger;
@@ -15,6 +16,12 @@ import java.util.Properties;
 public class PropertiesConfig implements IConfig
 {
     private static final Logger LOG = LoggerFactory.getLogger(PropertiesConfig.class.getSimpleName());
+
+    private static final IParameterValidator REQUIRED = (name, value) -> {
+        if (value == null){
+            throw new ParameterException("Parameter '" + name + "' is null");
+        }
+    };
 
     private Properties properties = new Properties();
 
@@ -80,7 +87,7 @@ public class PropertiesConfig implements IConfig
     @Override
     public String getPathToRecordingFile()
     {
-        return getProperty(PropertiesConstants.RECORDING_PATH);
+        return getProperty(PropertiesConstants.RECORDING_PATH, REQUIRED);
     }
 
     @Override
@@ -147,6 +154,11 @@ public class PropertiesConfig implements IConfig
     public String getPathToPreProcessorScript()
     {
         return getProperty(PropertiesConstants.PRE_PROCESS_SCRIPT_PATH);
+    }
+
+    @Override
+    public String getTargetBaseUrl() {
+        return getProperty(PropertiesConstants.TARGET_BASE_URL, REQUIRED);
     }
 
     @Override

--- a/player/src/main/java/com/focusit/jsflight/player/cli/config/PropertiesConstants.java
+++ b/player/src/main/java/com/focusit/jsflight/player/cli/config/PropertiesConstants.java
@@ -46,4 +46,6 @@ public class PropertiesConstants {
 
     public static final String XVFB_LOWER_BOUND = "xvfb.lower";
     public static final String XVFB_UPPER_BOUND = "xvfb.upper";
+
+    public static final String TARGET_BASE_URL = "target.baseUrl";
 }

--- a/player/src/main/java/com/focusit/jsflight/player/configurations/CommonConfiguration.java
+++ b/player/src/main/java/com/focusit/jsflight/player/configurations/CommonConfiguration.java
@@ -57,6 +57,7 @@ public class CommonConfiguration
     @Transient
     @JsonIgnore
     transient private ScriptsClassLoader scriptClassloader = null;
+    private CharSequence targetBaseUrl;
 
     public CommonConfiguration()
     {
@@ -268,5 +269,13 @@ public class CommonConfiguration
         {
             scriptClassloaderLock.unlock();
         }
+    }
+
+    public CharSequence getTargetBaseUrl() {
+        return targetBaseUrl;
+    }
+
+    public void setTargetBaseUrl(CharSequence targetBaseUrl) {
+        this.targetBaseUrl = targetBaseUrl;
     }
 }

--- a/player/src/main/java/com/focusit/jsflight/player/configurations/ScriptsConfiguration.java
+++ b/player/src/main/java/com/focusit/jsflight/player/configurations/ScriptsConfiguration.java
@@ -22,7 +22,7 @@ public class ScriptsConfiguration implements IDefaults
     @JsonIgnore
     private static final Logger LOG = LoggerFactory.getLogger(ScriptsConfiguration.class.getSimpleName());
 
-    @DefaultFile("jmeter/stpProcessor.groovy")
+    @DefaultFile("jmeter/stepProcessor.groovy")
     private String stepProcessorScript;
 
     @DefaultFile("jmeter/scenarioProcessor.groovy")
@@ -71,7 +71,9 @@ public class ScriptsConfiguration implements IDefaults
     private static String getScriptPathForField(Field field)
     {
         DefaultFile defaultFile = field.getAnnotation(DefaultFile.class);
-        return Paths.get(defaultFile.rootDirectory(), defaultFile.value()).toString();
+        String path = Paths.get(defaultFile.rootDirectory(), defaultFile.value()).toString();
+        LOG.info("Trying to read default script from {}", path);
+        return path;
     }
 
     private static Method getMethodWithPrefixForField(Field field, String prefix, Class<?>... parameterTypes)

--- a/player/src/main/java/com/focusit/jsflight/player/scenario/ScenarioProcessor.java
+++ b/player/src/main/java/com/focusit/jsflight/player/scenario/ScenarioProcessor.java
@@ -158,7 +158,7 @@ public class ScenarioProcessor
             //Configure webdriver for this event, setting params here so we can change parameters while playback is
             //paused
             seleniumDriver
-                    .setAsyncRequestsCompletedTimeoutInMs(
+                    .setAsyncRequestsCompletedTimeoutInSeconds(
                             commonConfiguration.getAsyncRequestsCompletedTimeoutInSeconds())
                     .setIsAsyncRequestsCompletedScript(scriptsConfiguration.getIsAsyncRequestsCompletedScript())
                     .setMaxElementGroovy(commonConfiguration.getMaxElementGroovy())

--- a/player/src/main/java/com/focusit/jsflight/player/scenario/UserScenario.java
+++ b/player/src/main/java/com/focusit/jsflight/player/scenario/UserScenario.java
@@ -55,6 +55,7 @@ public class UserScenario
         commonConfiguration.setFormOrDialogXpath(config.getKeepBrowserXpath());
         commonConfiguration.setUiShownTimeoutSeconds(config.getUiShownTimeoutInSeconds());
         commonConfiguration.setIntervalBetweenUiChecksMs(config.getIntervalBetweenUiChecksInMs());
+        commonConfiguration.setTargetBaseUrl(config.getTargetBaseUrl());
 
         ScriptsConfiguration scriptsConfiguration = getConfiguration().getScriptsConfiguration();
         scriptsConfiguration.setDuplicationHandlerScript(readFile(config.getPathToDuplicateHandlerScript()));

--- a/player/src/main/java/com/focusit/jsflight/player/webdriver/SeleniumDriver.java
+++ b/player/src/main/java/com/focusit/jsflight/player/webdriver/SeleniumDriver.java
@@ -78,7 +78,7 @@ public class SeleniumDriver
 
     private UserScenario scenario;
 
-    private int asyncRequestsCompletedTimeoutInMs;
+    private int asyncRequestsCompletedTimeoutInSeconds;
     private String isAsyncRequestsCompletedScript;
 
     private long intervalBetweenUiChecksInMs;
@@ -166,9 +166,9 @@ public class SeleniumDriver
         return this;
     }
 
-    public SeleniumDriver setAsyncRequestsCompletedTimeoutInMs(int asyncRequestsCompletedTimeoutInMs)
+    public SeleniumDriver setAsyncRequestsCompletedTimeoutInSeconds(int asyncRequestsCompletedTimeoutInSeconds)
     {
-        this.asyncRequestsCompletedTimeoutInMs = asyncRequestsCompletedTimeoutInMs;
+        this.asyncRequestsCompletedTimeoutInSeconds = asyncRequestsCompletedTimeoutInSeconds;
         return this;
     }
 
@@ -690,10 +690,10 @@ public class SeleniumDriver
         {
             return;
         }
-        LOG.info("Waiting while async requests will completed for {} seconds", asyncRequestsCompletedTimeoutInMs);
+        LOG.info("Waiting while async requests will completed for {} seconds", asyncRequestsCompletedTimeoutInSeconds);
         try
         {
-            new WebDriverWait(wd, asyncRequestsCompletedTimeoutInMs, 500).until((Predicate<WebDriver>)input -> {
+            new WebDriverWait(wd, asyncRequestsCompletedTimeoutInSeconds, 500).until((Predicate<WebDriver>) input -> {
                 try
                 {
                     Object result = ((JavascriptExecutor)wd).executeScript(isAsyncRequestsCompletedScript);
@@ -709,7 +709,7 @@ public class SeleniumDriver
         {
             throw new IllegalStateException(String.format(
                     "Async requests was not completed within specified timeout (%ds): %s",
-                    asyncRequestsCompletedTimeoutInMs, event.getString(EventConstants.URL)));
+                    asyncRequestsCompletedTimeoutInSeconds, event.getString(EventConstants.URL)));
         }
     }
 

--- a/player/src/main/resources/application-default.properties
+++ b/player/src/main/resources/application-default.properties
@@ -41,3 +41,5 @@ ui.checksIntervalInMs=
 
 xvfb.lower=
 xvfb.upper=
+
+target.baseUrl=

--- a/server/src/main/java/com/focusit/jsflight/server/player/BackgroundWebPlayer.java
+++ b/server/src/main/java/com/focusit/jsflight/server/player/BackgroundWebPlayer.java
@@ -105,8 +105,8 @@ public class BackgroundWebPlayer
         experiment.setRecordingId(rec.getId());
         experiment.setScreenshots(withScreenshots);
         experiment.setSteps((int)eventRepository.countByRecordingId(new ObjectId(recordingId)));
-        experiment.setPosition(0);
-        experiment.setLimit(0);
+        experiment.setPosition(config.getStartStep());
+        experiment.setLimit(config.getFinishStep());
 
         experimentRepository.save(experiment);
 

--- a/server/src/main/java/com/focusit/jsflight/server/scenario/MongoDbScenario.java
+++ b/server/src/main/java/com/focusit/jsflight/server/scenario/MongoDbScenario.java
@@ -1,13 +1,14 @@
 package com.focusit.jsflight.server.scenario;
 
+import org.bson.types.ObjectId;
+import org.json.JSONObject;
+
 import com.focusit.jsflight.player.configurations.Configuration;
 import com.focusit.jsflight.player.scenario.UserScenario;
 import com.focusit.jsflight.server.model.Event;
 import com.focusit.jsflight.server.model.Experiment;
 import com.focusit.jsflight.server.repository.EventRepository;
 import com.focusit.jsflight.server.repository.ExperimentRepository;
-import org.bson.types.ObjectId;
-import org.json.JSONObject;
 
 /**
  * This class wraps an experiment in user scenario.
@@ -20,8 +21,7 @@ public class MongoDbScenario extends UserScenario
     private EventRepository repository;
     private ExperimentRepository experimentRepository;
 
-    public MongoDbScenario(Experiment experiment, EventRepository repository,
-            ExperimentRepository experimentRepository)
+    public MongoDbScenario(Experiment experiment, EventRepository repository, ExperimentRepository experimentRepository)
     {
         this.experiment = experiment;
         this.repository = repository;
@@ -61,6 +61,8 @@ public class MongoDbScenario extends UserScenario
         {
             throw new IllegalArgumentException("No event found at position " + position);
         }
+        event.setUrl(event.getUrl()
+                .replace("0.0.0.0:0", getConfiguration().getCommonConfiguration().getTargetBaseUrl()));
         return new JSONObject(event);
     }
 


### PR DESCRIPTION
 - Add `targetBaseUrl` startup property
 - Fix typo in ScriptsConfiguration
 - Fix ignoring of the start/finish step in server
 - Update new recordings loading logic. Replace url base with template 0.0.0.0:0

`targetBaseUrl` - is the property, that defines the target host of the clicks playing, e.g. 127.0.0.1:2313