### PR TITLE
Fix slf4j conflicts

### DIFF
--- a/player/pom.xml
+++ b/player/pom.xml
@@ -30,10 +30,6 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.d0k1.jsflight</groupId>
             <artifactId>jmeter</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <ApacheJMeter.version>3.0</ApacheJMeter.version>
+        <ApacheJMeter.version>3.1</ApacheJMeter.version>
         <ApacheJMeter_java.version>2.13</ApacheJMeter_java.version>
         <annotations.version>2.0.2</annotations.version>
         <buildnumber-maven-plugin.version>1.3</buildnumber-maven-plugin.version>
@@ -60,7 +60,6 @@
         <spock-spring.version>1.0-groovy-2.4</spock-spring.version>
         <velocity.version>1.7</velocity.version>
         <maven-release-plugin.version>2.3.2</maven-release-plugin.version>
-        <velocity.version>1.7</velocity.version>
     </properties>
 
     <parent>
@@ -85,11 +84,6 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>${log4j2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jcl</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
             <dependency>
@@ -312,7 +306,7 @@
             <dependency>
                 <groupId>org.apache.jmeter</groupId>
                 <artifactId>ApacheJMeter_java</artifactId>
-                <version>${ApacheJMeter_java.version}</version>
+                <version>${ApacheJMeter.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.codehaus.groovy</groupId>
@@ -348,13 +342,6 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.apache.velocity/velocity -->
-            <dependency>
-                <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>${velocity.version}</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -35,10 +35,6 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.d0k1.jsflight</groupId>
             <artifactId>player</artifactId>
             <exclusions>

--- a/server/src/main/resources/log4j2-spring.xml
+++ b/server/src/main/resources/log4j2-spring.xml
@@ -21,14 +21,15 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="com.focusit" level="error">
+        <!--Log levels sorted ascending by verbosity: OFF/FATAL/ERROR/WARN/INFO/DEBUG/TRACE/ALL-->
+        <Logger name="com.focusit" level="info">
             <AppenderRef ref="SERVER_FILE" />
         </Logger>
-        <Logger name="org.apache.jmeter.protocol.http.proxy" level="error">
+        <Logger name="org.apache.jmeter.protocol.http.proxy" level="warn">
             <AppenderRef ref="JMETER_FILE" />
         </Logger>
 
-        <Root level="trace">
+        <Root level="info">
             <AppenderRef ref="STDOUT"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
 * Exclude all log4j below version 2. 
 * Update JMeter to 3.1 to fix slf4j conflicts (were hardcoded previously)